### PR TITLE
Add recommendation for merging without fast forward

### DIFF
--- a/common-flow.md
+++ b/common-flow.md
@@ -93,6 +93,12 @@ interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
     4. It is RECOMMENDED that you always do "git pull --rebase" instead of "git
        pull" to avoid unnecessary merge commits. You can make this the default
        behavior of "git pull" with "git config --global pull.rebase true".
+    5. It is RECOMMENDED that all branches be merged using "git merge --no-ff".
+       This makes sure the reference to the original branch is kept in the 
+       commits, allows one to revert a merge by reverting a single merge 
+       commit, and creates a merge commit to mark the integration of the 
+       branch with master.
+       https://aaronbonner.io/post/78444674979/only-allow-git-fast-forward-merges-to-avoid-ugly
 4. Versioning
     1. The project MUST have its version hard-coded somewhere in the
        code-base. It is RECOMMENDED that this is done in a file called "VERSION"


### PR DESCRIPTION
git merge removes the link to the original branch, and makes a messy merge commit.